### PR TITLE
bump supported PHP version

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -16,7 +16,7 @@
         }
     ],
     "require": {
-        "php": "^5.5|^7.0",
+        "php": "^7.2|^8.0",
         "friendsofsymfony/oauth2-php": "~1.1",
         "symfony/framework-bundle": "~2.8|~3.0|^4.0",
         "symfony/security-bundle": "~2.8|~3.0|^4.0",


### PR DESCRIPTION
hi @dennisameling 

while working on php 8 support for Mautic, I noticed this fork isn't compatible with PHP 8 (which makes sense, as it's meant to tackle an old issue in the upstream version).

To be able to support php 8 for Mautic 4 with minimal effort and without BC breaking changes, we just need a small change.

The bigger overhaul will be for Mautic 5, where breaking changes are possible 